### PR TITLE
Fluentd expects record keys as String, not Symbol

### DIFF
--- a/lib/fluent/plugin/in_mysql_slow_query.rb
+++ b/lib/fluent/plugin/in_mysql_slow_query.rb
@@ -37,15 +37,15 @@ class MySQLSlowQueryInput < TailInput
     es = MultiEventStream.new
     @parser.divide(lines).each do |record|
       begin
-        record = @parser.parse_record(record)
-        if time = record.delete(:date)
+        record = stringify_keys @parser.parse_record(record)
+        if time = record.delete('date')
           time = time.to_i
         else
           time = Time.now.to_i
         end
 
-        if record[:db].nil? || record[:db].empty?
-          record[:db] = @last_use_database ? @last_use_database : search_last_use_database()
+        if record['db'].nil? || record['db'].empty?
+          record['db'] = @last_use_database ? @last_use_database : search_last_use_database()
         end
 
         es.add(time, record)
@@ -60,6 +60,16 @@ class MySQLSlowQueryInput < TailInput
         Engine.emit_stream(@tag, es)
       rescue
       end
+    end
+
+    private
+
+    def stringify_keys(record)
+      result = {}
+      record.each_key do |key|
+        result[key.to_s] = record[key]
+      end
+      result
     end
   end
 end

--- a/lib/fluent/plugin/in_mysql_slow_query.rb
+++ b/lib/fluent/plugin/in_mysql_slow_query.rb
@@ -61,16 +61,16 @@ class MySQLSlowQueryInput < TailInput
       rescue
       end
     end
+  end
 
-    private
+  private
 
-    def stringify_keys(record)
-      result = {}
-      record.each_key do |key|
-        result[key.to_s] = record[key]
-      end
-      result
+  def stringify_keys(record)
+    result = {}
+    record.each_key do |key|
+      result[key.to_s] = record[key]
     end
+    result
   end
 end
 


### PR DESCRIPTION
"Fluentd plugins assume the record is a JSON so the key should be the String, not Symbol. If you emit a symbol keyed record, it may cause a problem." (from http://docs.fluentd.org/articles/plugin-development)