### PR TITLE
Use router attr_accessor instead of raw Engine

### DIFF
--- a/lib/fluent/plugin/in_mysql_slow_query.rb
+++ b/lib/fluent/plugin/in_mysql_slow_query.rb
@@ -57,7 +57,7 @@ class MySQLSlowQueryInput < TailInput
 
     unless es.empty?
       begin
-        Engine.emit_stream(@tag, es)
+        router.emit_stream(@tag, es)
       rescue
       end
     end


### PR DESCRIPTION
In fluentd 0.12 or later, `router` is a attr_accessor.
Users can use `EventRouter#emit_stream` via `router`.