### PR TITLE
migrate fluent plugin mysqlslowquery to v0.14 api

### DIFF
--- a/lib/fluent/plugin/in_mysql_slow_query.rb
+++ b/lib/fluent/plugin/in_mysql_slow_query.rb
@@ -14,11 +14,12 @@
 # limitations under the License.
 #
 require "myslog"
+require "fluent/plugin/in_tail"
 
-module Fluent
+module Fluent::Plugin
 
-class MySQLSlowQueryInput < TailInput
-  Plugin.register_input('mysql_slow_query', self)
+class MySQLSlowQueryInput < Fluent::Plugin::TailInput
+  Fluent::Plugin.register_input('mysql_slow_query', self)
 
   def configure_parser(conf)
     @parser = MySlog.new


### PR DESCRIPTION
close #19 

[see also jp article about fluentd v0.14 migration](http://www.clear-code.com/blog/2016/8/26.html)