### PR TITLE
make compatible with td-agent 3.x / fluentd 1.x

### DIFF
--- a/fluent-plugin-mysqlslowquery.gemspec
+++ b/fluent-plugin-mysqlslowquery.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "fluent-plugin-mysqlslowquery"
   gem.require_paths = ["lib"]
-  gem.version       = "0.0.8"
+  gem.version       = "0.0.9"
   gem.add_dependency "fluentd", [">= 0.12.0", "< 2"]
   gem.add_dependency "myslog", "~> 0.0"
 end

--- a/lib/fluent/plugin/in_mysql_slow_query.rb
+++ b/lib/fluent/plugin/in_mysql_slow_query.rb
@@ -18,11 +18,11 @@ require "fluent/plugin/in_tail"
 
 module Fluent::Plugin
 
-class MySQLSlowQueryInput < Fluent::Plugin::TailInput
+class MySQLSlowQueryInput < TailInput
   Fluent::Plugin.register_input('mysql_slow_query', self)
 
-  def configure_parser(conf)
-    @parser = MySlog.new
+  def parser_create(conf)
+    return MySlog.new
   end
 
   def search_last_use_database
@@ -34,8 +34,8 @@ class MySQLSlowQueryInput < Fluent::Plugin::TailInput
     end
   end
 
-  def receive_lines(lines)
-    es = MultiEventStream.new
+  def receive_lines(lines, tail_watcher)
+    es = Fluent::MultiEventStream.new
     @parser.divide(lines).each do |record|
       begin
         record = stringify_keys @parser.parse_record(record)


### PR DESCRIPTION
This addresses #21 and #18 and makes this compatible with td-agent 3.x (fluentd 1.x).